### PR TITLE
TM: fix image size in markdown

### DIFF
--- a/app/components/MarkdownRender/styledComponents.js
+++ b/app/components/MarkdownRender/styledComponents.js
@@ -28,7 +28,7 @@ export const Body = styled.div`
     background: white;
     color: ${textColor};
     font-family: inherit;
-    width: 100%;
+    max-width: 100%;
   }
 
   a {


### PR DESCRIPTION
One liner fix. Small images were too stretched out in the markdown body. 