### PR TITLE
Fix image size in markdown  

### DIFF
--- a/app/components/MarkdownRender/styledComponents.js
+++ b/app/components/MarkdownRender/styledComponents.js
@@ -28,7 +28,7 @@ export const Body = styled.div`
     background: white;
     color: ${textColor};
     font-family: inherit;
-    width: 100%;
+    max-width: 100%;
   }
 
   a {


### PR DESCRIPTION
Small images were forced to be 100% width in markdown body. Just changed to `max-width` instead