### PR TITLE
Fix deleted user link

### DIFF
--- a/app/components/Issues/Detail/IssueDetailBody.jsx
+++ b/app/components/Issues/Detail/IssueDetailBody.jsx
@@ -17,7 +17,7 @@ import {
   StyledLanguageAutocomplete,
   StyledMarkdown,
   UsernameLink,
-  Username,
+  DeletedName,
 } from './styledComponents';
 import { issueTags, tagColors } from '../constants';
 import { TagWrapper } from '../styledComponents';
@@ -82,7 +82,7 @@ const IssueDetailBody = ({
         <div>
           Opened by{' '}
           {username === '[deleted]' ? (
-            <Username>{username}</Username>
+            <DeletedName>{username}</DeletedName>
           ) : (
             <UsernameLink to={route}>{username}</UsernameLink>
           )}{' '}

--- a/app/components/Issues/Detail/IssueDetailBody.jsx
+++ b/app/components/Issues/Detail/IssueDetailBody.jsx
@@ -17,7 +17,6 @@ import {
   StyledLanguageAutocomplete,
   StyledMarkdown,
   UsernameLink,
-  DeletedName,
 } from './styledComponents';
 import { issueTags, tagColors } from '../constants';
 import { TagWrapper } from '../styledComponents';
@@ -76,17 +75,17 @@ const IssueDetailBody = ({
     </InfoItemWrapper>
   );
 
+  const isUserDeleted = username === '[deleted]';
+
   return (
     <Fragment>
       <PostingInfoWrapper>
         <div>
-          Opened by{' '}
-          {username === '[deleted]' ? (
-            <DeletedName>{username}</DeletedName>
-          ) : (
-            <UsernameLink to={route}>{username}</UsernameLink>
-          )}{' '}
-          on&nbsp;
+          Opened by&nbsp;
+          <UsernameLink isUserDeleted={isUserDeleted} to={route}>
+            {username}
+          </UsernameLink>
+          &nbsp;on&nbsp;
           {moment(date)
             .utc()
             .format('M/D/YYYY')}

--- a/app/components/Issues/Detail/IssueDetailBody.jsx
+++ b/app/components/Issues/Detail/IssueDetailBody.jsx
@@ -17,6 +17,7 @@ import {
   StyledLanguageAutocomplete,
   StyledMarkdown,
   UsernameLink,
+  Username,
 } from './styledComponents';
 import { issueTags, tagColors } from '../constants';
 import { TagWrapper } from '../styledComponents';
@@ -79,7 +80,13 @@ const IssueDetailBody = ({
     <Fragment>
       <PostingInfoWrapper>
         <div>
-          Opened by <UsernameLink to={route}>{username}</UsernameLink> on&nbsp;
+          Opened by{' '}
+          {username === '[deleted]' ? (
+            <Username>{username}</Username>
+          ) : (
+            <UsernameLink to={route}>{username}</UsernameLink>
+          )}{' '}
+          on&nbsp;
           {moment(date)
             .utc()
             .format('M/D/YYYY')}

--- a/app/components/Issues/Detail/styledComponents.js
+++ b/app/components/Issues/Detail/styledComponents.js
@@ -304,16 +304,15 @@ export const TopBarWrapper = styled.div`
   height: 10rem;
 `;
 
-export const UsernameLink = styled(Link)`
+export const UsernameLink = styled(({ isUserDeleted, ...restProps }) => (
+  <Link {...restProps} />
+))`
   display: inline;
   font-weight: bold;
+  pointer-events: ${({ isUserDeleted }) =>
+    isUserDeleted ? 'none' : 'inherit'};
 
   &:hover {
-    color: ${hoverLinkColor};
+    text-decoration: underline;
   }
-`;
-
-export const DeletedName = styled.div`
-  display: inline;
-  font-weight: bold;
 `;

--- a/app/components/Issues/Detail/styledComponents.js
+++ b/app/components/Issues/Detail/styledComponents.js
@@ -312,3 +312,8 @@ export const UsernameLink = styled(Link)`
     color: ${hoverLinkColor};
   }
 `;
+
+export const DeletedName = styled.div`
+  display: inline;
+  font-weight: bold;
+`;

--- a/app/components/MarkdownRender/Comments/CommentCard.jsx
+++ b/app/components/MarkdownRender/Comments/CommentCard.jsx
@@ -13,7 +13,6 @@ import {
   FlexContainer,
   ProfileImageContainer,
   UsernameLink,
-  DeletedName,
 } from '../styledComponents';
 
 const CommentCard = ({
@@ -24,6 +23,8 @@ const CommentCard = ({
   const html = marked(body);
   const cleanHtml = DOMPurify.sanitize(html);
 
+  const isUserDeleted = username === '[deleted]';
+
   return (
     <FlexContainer>
       <ProfileImageContainer>
@@ -32,12 +33,10 @@ const CommentCard = ({
       <CommentContainer>
         <CommentHeader>
           <span>
-            Posted by&nbsp;{' '}
-            {username === '[deleted]' ? (
-              <DeletedName>{username}</DeletedName>
-            ) : (
-              <UsernameLink to={route}>{username}</UsernameLink>
-            )}{' '}
+            Posted by&nbsp;
+            <UsernameLink isUserDeleted={isUserDeleted} to={route}>
+              {username}
+            </UsernameLink>
           </span>
           &nbsp;
           {moment(date)

--- a/app/components/MarkdownRender/Comments/CommentCard.jsx
+++ b/app/components/MarkdownRender/Comments/CommentCard.jsx
@@ -13,6 +13,7 @@ import {
   FlexContainer,
   ProfileImageContainer,
   UsernameLink,
+  DeletedName,
 } from '../styledComponents';
 
 const CommentCard = ({
@@ -31,7 +32,12 @@ const CommentCard = ({
       <CommentContainer>
         <CommentHeader>
           <span>
-            Posted by&nbsp;<UsernameLink to={route}>{username}</UsernameLink>
+            Posted by&nbsp;{' '}
+            {username === '[deleted]' ? (
+              <DeletedName>{username}</DeletedName>
+            ) : (
+              <UsernameLink to={route}>{username}</UsernameLink>
+            )}{' '}
           </span>
           &nbsp;
           {moment(date)

--- a/app/components/MarkdownRender/styledComponents.js
+++ b/app/components/MarkdownRender/styledComponents.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 
@@ -189,17 +190,15 @@ export const UsernameExternalLink = styled.a`
   }
 `;
 
-export const UsernameLink = styled(Link)`
+export const UsernameLink = styled(({ isUserDeleted, ...restProps }) => (
+  <Link {...restProps} />
+))`
   display: inline;
   font-weight: bold;
+  pointer-events: ${({ isUserDeleted }) =>
+    isUserDeleted ? 'none' : 'inherit'};
 
   &:hover {
     text-decoration: underline;
   }
-`;
-
-export const DeletedName = styled(Link)`
-  display: inline;
-  font-weight: bold;
-  cursor: default;
 `;

--- a/app/components/MarkdownRender/styledComponents.js
+++ b/app/components/MarkdownRender/styledComponents.js
@@ -197,3 +197,9 @@ export const UsernameLink = styled(Link)`
     text-decoration: underline;
   }
 `;
+
+export const DeletedName = styled(Link)`
+  display: inline;
+  font-weight: bold;
+  cursor: default;
+`;


### PR DESCRIPTION
## RYSOLV

Fixes #104 

Username links for deleted users are non clickable. I added styling for Deleted Users to remove hovering effects and added checks for if user is deleted on IssueDetailBody and CommentCard.