### PR TITLE
Hotfix: fixed percentages on language chart

### DIFF
--- a/app/components/UserProfile/LanguageChart/index.jsx
+++ b/app/components/UserProfile/LanguageChart/index.jsx
@@ -10,9 +10,11 @@ import {
   TitleRow,
 } from './styledComponents';
 
-const LanguageChart = ({ languages }) => {
+const LanguageChart = ({ githubStats, languages }) => {
+  const { commits: totalCommits } = githubStats;
+
   const graph = languages.map(({ commits, language }) => {
-    const width = (commits / 2500) * 100;
+    const width = (commits / totalCommits) * 100;
     return (
       <LanguageRow key={language}>
         <LanguageBar width={width}>{language}</LanguageBar>
@@ -33,6 +35,7 @@ const LanguageChart = ({ languages }) => {
 };
 
 LanguageChart.propTypes = {
+  githubStats: T.object,
   languages: T.array,
 };
 

--- a/app/components/UserProfile/index.jsx
+++ b/app/components/UserProfile/index.jsx
@@ -169,7 +169,10 @@ const UserProfile = ({ data, handleNav }) => {
               <ProfileSection>
                 <DetailCharts>
                   <SummaryChart githubStats={githubStats} />
-                  <LanguageChart languages={languageByCommits} />
+                  <LanguageChart
+                    githubStats={githubStats}
+                    languages={languageByCommits}
+                  />
                 </DetailCharts>
               </ProfileSection>
 


### PR DESCRIPTION
This was previously dividing everything by 2500 (some testing number I was using) 
Pulled in the actual commit count instead.